### PR TITLE
Add multi-step onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# formic
+# Formic
+
+This repository contains a basic Next.js layout built with Tailwind CSS.
+
+The layout includes:
+- A fixed sidebar for navigating campaign threads.
+- A top bar with placeholder filter dropdowns.
+- A main content area for story threads.
+- A collapsible chat panel on the right.
+- A multi-step onboarding flow available at `/onboarding`.
+
+Run `npm run dev` to start the development server once dependencies are installed.

--- a/components/ChatPanel.tsx
+++ b/components/ChatPanel.tsx
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+export default function ChatPanel() {
+  const [open, setOpen] = useState(true)
+  const width = open ? 'w-64' : 'w-10'
+
+  return (
+    <div className={`bg-gray-100 border-l h-full flex flex-col ${width}`}>
+      <button className="p-2" onClick={() => setOpen(!open)}>
+        {open ? '>' : '<'}
+      </button>
+      {open && (
+        <div className="p-4 flex-1">
+          <p>Ask Formic something…</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,23 @@
+import Sidebar from './Sidebar'
+import TopBar from './TopBar'
+import MainContent from './MainContent'
+import ChatPanel from './ChatPanel'
+
+export default function Layout() {
+  return (
+    <div className="flex h-screen">
+      <div className="hidden md:block">
+        <Sidebar />
+      </div>
+      <div className="flex flex-col flex-1">
+        <TopBar />
+        <div className="flex flex-1 overflow-hidden">
+          <MainContent />
+          <div className="hidden sm:block">
+            <ChatPanel />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/MainContent.tsx
+++ b/components/MainContent.tsx
@@ -1,0 +1,7 @@
+export default function MainContent() {
+  return (
+    <main className="p-4 overflow-auto flex-1">
+      <p>Story thread content appears here</p>
+    </main>
+  )
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,11 @@
+export default function Sidebar() {
+  return (
+    <aside className="bg-gray-800 text-white w-60 p-4 h-full">
+      <h2 className="text-lg font-semibold mb-4">Campaigns</h2>
+      <ul className="space-y-2">
+        <li className="hover:underline cursor-pointer">Campaign A</li>
+        <li className="hover:underline cursor-pointer">Campaign B</li>
+      </ul>
+    </aside>
+  )
+}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,0 +1,12 @@
+export default function TopBar() {
+  const filters = ['Campaign', 'Channel', 'Timeframe', 'Outcome']
+  return (
+    <header className="flex space-x-4 p-4 border-b bg-white">
+      {filters.map((f) => (
+        <select key={f} className="border rounded p-2">
+          <option>{f}</option>
+        </select>
+      ))}
+    </header>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/typescript

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: false
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "formic",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.15",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.5",
+    "typescript": "5.2.2",
+    "@types/react": "18.2.24",
+    "@types/node": "20.6.1"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app'
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head'
+import Layout from '../components/Layout'
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Formic</title>
+      </Head>
+      <Layout />
+    </>
+  )
+}

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import Head from 'next/head'
+
+const roles = ['CMO', 'Head of Growth', 'Marketing Ops', 'Other']
+const priorities = [
+  'Customer Acquisition',
+  'Pipeline Influence',
+  'Retention',
+  'Creative Testing',
+  'Efficiency',
+  'All of the Above',
+]
+const platforms = ['Meta', 'Google Ads', 'GA4', 'Klaviyo', 'Mailchimp', 'LinkedIn Ads']
+
+export default function Onboarding() {
+  const [step, setStep] = useState(1)
+  const [role, setRole] = useState('')
+  const [selectedPriorities, setSelectedPriorities] = useState<string[]>([])
+  const [connectedPlatforms, setConnectedPlatforms] = useState<string[]>([])
+
+  const togglePriority = (p: string) => {
+    setSelectedPriorities((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p]
+    )
+  }
+
+  const togglePlatform = (p: string) => {
+    setConnectedPlatforms((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p]
+    )
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Onboarding - Formic</title>
+      </Head>
+      <div className="p-4 max-w-lg mx-auto">
+        {step === 1 && (
+          <div className="space-y-6">
+            <div>
+              <h1 className="text-2xl font-bold">Welcome to Formic</h1>
+              <p className="text-gray-600">Let’s configure your strategic memory system</p>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <p className="font-medium mb-2">What is your role?</p>
+                {roles.map((r) => (
+                  <label key={r} className="block">
+                    <input
+                      type="radio"
+                      name="role"
+                      className="mr-2"
+                      value={r}
+                      checked={role === r}
+                      onChange={() => setRole(r)}
+                    />
+                    {r}
+                  </label>
+                ))}
+              </div>
+              <div>
+                <p className="font-medium mb-2">What does Formic need to prioritize for you?</p>
+                {priorities.map((p) => (
+                  <label key={p} className="block">
+                    <input
+                      type="checkbox"
+                      className="mr-2"
+                      checked={selectedPriorities.includes(p)}
+                      onChange={() => togglePriority(p)}
+                    />
+                    {p}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <button
+              className="bg-blue-600 text-white px-4 py-2 rounded"
+              onClick={() => setStep(2)}
+            >
+              Continue
+            </button>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-6">
+            <h1 className="text-2xl font-bold">Connect your marketing platforms</h1>
+            <div className="space-y-2">
+              {platforms.map((p) => (
+                <label key={p} className="flex items-center">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={connectedPlatforms.includes(p)}
+                    onChange={() => togglePlatform(p)}
+                  />
+                  {p}
+                </label>
+              ))}
+            </div>
+            <button
+              className="bg-blue-600 text-white px-4 py-2 rounded"
+              onClick={() => setStep(3)}
+            >
+              Continue
+            </button>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-6 text-center">
+            <h1 className="text-2xl font-bold">Setup Complete. Let’s start analyzing.</h1>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- include new onboarding route
- collect role, priorities and platform choices in a 3-step wizard
- mention onboarding page in README

## Testing
- `npm run lint` *(fails: next not found)*